### PR TITLE
adding Gitter badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,11 @@ Your favorite service is missing? [Pull Requests welcome](CONTRIBUTING.md).
 #### Waffle
 [![Stories in Ready](https://badge.waffle.io/boennemann/badges.png?label=ready)](https://waffle.io/boennemann/badges)
 
+### Chat
+
+#### Gitter
+[![Join the chat at https://gitter.im/jstriebel/badges](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/jstriebel/badges)
+
 ### Generic
 
 #### Shields.io


### PR DESCRIPTION
Hi @boennemann,

this badge is pointing to the Gitter-Chat of my fork, as I can only create Chats for my own repos. Again, please feel free to create a Chat pointing to your Repo ([login](https://gitter.im) with :octocat: is possible).

Thanks for considering this PR, best,
Jonathan