### PR TITLE
Adding wercker

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Your favorite service is missing? [Pull Requests welcome](CONTRIBUTING.md).
 ### TravisCI
 [![Build Status](https://travis-ci.org/boennemann/badges.svg?branch=master)](https://travis-ci.org/boennemann/badges)
 
+### wercker
+[![wercker status](https://app.wercker.com/status/f0518e6870c40bb93878fe5c6f1cb3c1/m/master "wercker status")](https://app.wercker.com/project/bykey/f0518e6870c40bb93878fe5c6f1cb3c1)
+
 ## Package Information
 
 ### Bower

--- a/wercker.yml
+++ b/wercker.yml
@@ -1,0 +1,7 @@
+box: phusion/baseimage
+build:
+  steps:
+    - script:
+        name: echo
+        code: |
+          echo "hello world!"


### PR DESCRIPTION
Hello @boennemann ,

I would like to add wercker, another CI service. The badge currently points to the wercker project of my fork, as you can only set it up for your own projects.
Please feel free to setup your own wercker project (you can [login](http://wercker.com) with your :octocat: account) and change the badge.

Thanks for considering this PR,
Cheers,
  Jonathan