### PR TITLE
Adds Codecov (Test Coverage)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,11 @@
 language: node_js
 node_js:
   - '0.10'
+before_install:
+  - pip install --user codecov
 after_success:
   - ./node_modules/grunt-cli/bin/grunt coveralls
+  - codecov --file coverage/lcov.info --disable search
 cache:
   directories:
     - node_modules

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - pip install --user codecov
 after_success:
   - ./node_modules/grunt-cli/bin/grunt coveralls
-  - codecov --file coverage/lcov.info --disable search
+  - codecov --file coverage/'PhantomJS 1.9.8 (Linux 0.0.0)'/lcov.info --disable search
 cache:
   directories:
     - node_modules

--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ Your favorite service is missing? [Pull Requests welcome](CONTRIBUTING.md).
 
 ## Test Coverage
 
+### Codecov - https://codecov.io/#features
+[![codecov.io](https://codecov.io/github/nelsonic/badges/coverage.svg?branch=master)](https://codecov.io/github/nelsonic/badges?branch=master)
+
 ### Coveralls
 [![Coverage Status](https://coveralls.io/repos/boennemann/badges/badge.png)](https://coveralls.io/r/boennemann/badges)
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Your favorite service is missing? [Pull Requests welcome](CONTRIBUTING.md).
 ## Test Coverage
 
 ### Codecov - https://codecov.io/#features
-[![codecov.io](https://codecov.io/github/nelsonic/badges/coverage.svg?branch=master)](https://codecov.io/github/nelsonic/badges?branch=master)
+[![codecov.io](https://codecov.io/github/boennemann/badges/coverage.svg?branch=master)](https://codecov.io/github/boennemann/badges?branch=master)
 
 ### Coveralls
 [![Coverage Status](https://coveralls.io/repos/boennemann/badges/badge.png)](https://coveralls.io/r/boennemann/badges)

--- a/README.md
+++ b/README.md
@@ -52,8 +52,10 @@ Your favorite service is missing? [Pull Requests welcome](CONTRIBUTING.md).
 
 ## Test Coverage
 
-### Codecov - https://codecov.io/#features
+### Codecov
 [![codecov.io](https://codecov.io/github/boennemann/badges/coverage.svg?branch=master)](https://codecov.io/github/boennemann/badges?branch=master)
+> Features: https://codecov.io/#features  
+> Codecov instructions/example for your Language see: https://codecov.io/#languages
 
 ### Coveralls
 [![Coverage Status](https://coveralls.io/repos/boennemann/badges/badge.png)](https://coveralls.io/r/boennemann/badges)


### PR DESCRIPTION
Hi @boennemann, 
As discussed in https://github.com/boennemann/badges/issues/43
The coverage report for this PR: https://codecov.io/github/boennemann/badges?pr=44

You will need to sign-in to https://codecov.io/github/boennemann/badges and then add the repo.
Then restart the Travis Build to ensure the coverage report is sent to Codecov.
Once merged the Badge will work. :+1: 

CC: @stevepeak