### PR TITLE
Fixed travis-ci fail bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "registry": "https://registry.bower.io"
+}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
+  - '4.9.1'
 before_install:
   - pip install --user codecov
 after_success:


### PR DESCRIPTION
Bower is deprecating their registry hosted with Heroku.
Change to [https://registry.bower.io](https://registry.bower.io)

Update node version to use `const` without `'use strict';`